### PR TITLE
Simplify player setup with one VR installer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,103 @@
-# MGS5VR — native stereo experiment
+# MGS5VR
 
-[![Windows build](https://github.com/nikamigaming-create/MGS5VR/actions/workflows/windows.yml/badge.svg?branch=main)](https://github.com/nikamigaming-create/MGS5VR/actions/workflows/windows.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-![Platform: Windows x64](https://img.shields.io/badge/platform-Windows%20x64-blue)
-![API: D3D11 + OpenXR](https://img.shields.io/badge/API-D3D11%20%2B%20OpenXR-blue)
-[![Status: experimental](https://img.shields.io/badge/status-experimental-orange)](docs/STATUS.md)
+Play **Metal Gear Solid V: The Phantom Pain** in first-person VR, with tracked
+hands and a weapon HUD on your **left forearm**.
 
-The mod's implementation, native build adapters, tests and build tooling are open source under the [MIT license](LICENSE). Dependencies are pinned open-source projects with [retained notices](docs/THIRD_PARTY_NOTICES.md). Building requires no private mod code. Running requires your own installation of the game and an OpenXR runtime; neither is redistributed here. This is an independent community project.
+**Experimental:** the current Quest 3 build received positive basic gameplay
+feedback. Sharpness, arm polish and complete interaction testing remain unfinished.
+See [what has been tested](docs/STATUS.md).
 
-This repository is **not a complete VR conversion of The Phantom Pain**. It is a native Windows x64/D3D11/OpenXR development experiment. An opt-in native scene hook draws both eyes within one game render transaction and submits a projection layer. The controller experiment now drives native hands and the rifle, with controller-directed muzzle and projectile output observed for the AM MRS-4. Physical alignment and all-state acceptance remain incomplete. An opt-in left-forearm weapon/status HUD is now implemented. Full arm/menu interaction and universal cinematic skipping remain incomplete.
+**Setup in one line:** connect your headset → download and extract → run the
+installer once → launch MGSV → load your save and enter VR.
 
-The requested gameplay view is first person: six-axis head tracking, tracked hands and equipped gear, and weapon/status UI on the left forearm. Complete native menus use a large spatial screen. See the [latest simulator review](docs/SIM_HUD_REVIEW.md) and [complete controls](docs/CONTROLS.md) for the tested slice and its limits.
+## Before you start
 
-The current Quest 3 run of build `7BF543BE` received positive user feedback for the basic VR experience, with low resolution and jagged edges remaining. A higher native resolution is now under physical test with the same mod binary; see the [sharpness review](docs/HEADSET_SHARPNESS_REVIEW.md). Earlier builds failed stereo and limb presentation and remain failed references. The current build crops centered renders to each eye's requested optics and places equipment cards above the left wrist. [SIM evidence](docs/SKY_CROP_REVIEW.md) includes a short recording. Complete gameplay and visual acceptance remain unfinished; this is not a polished release.
+- **Windows x64 and your own PC copy of The Phantom Pain 1.0.15.4.** The installer checks the supported executable.
+- **A PC-connected OpenXR headset.** Quest 3 with Touch controllers is the tested setup. Start your PC VR connection and select your headset software as the active OpenXR runtime. Other headsets and controller layouts are unverified.
+- The [Microsoft Visual C++ v14 x64 Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist), if it is not already installed.
+- Close MGSV. Another mod using `dinput8.dll`, including IHHook, conflicts with this build; the installer preserves existing files.
 
-The default mode captures the game's desktop image onto a large, world-anchored OpenXR quad. With `-EnableHeadCameraExperiment`, left grip plus left stick click toggles experimental native head tracking and same-frame stereo. Both eye cameras use one tracking snapshot; alternate-eye rendering is not used. The camera now anchors to the player's head bone and excludes the player's head model and body group while retaining arm groups. Aiming stays in stereo with the weapon's actual sights; optical zoom is reserved. iDroid and pause automatically use the large screen and restore tracked VR when the same player camera resumes. OpenXR controllers feed the game's own XInput import, without Windows key/mouse injection or window activation. Complete cinematic/loading transitions remain unverified.
+You do not need Visual Studio, a simulator, or to compile anything.
 
-## Build
+## Install once
 
-Requires Windows x64, Visual Studio 2022 C++ build tools and Windows SDK, Git, CMake 3.24+, and Python 3. Run from this repository:
-
-```powershell
-.\tools\build.ps1
-```
-
-Dependencies are pinned: Khronos OpenXR SDK 1.1.49 (`977f6675...`), MinHook 1.3.4 (`c3fcafdc...`). The OpenXR loader is statically linked. The Visual C++ runtime is required. Build outputs are in `build/Release/`.
-
-The Windows CI badge reports the real build and four tests that do not require a GPU. The fifth suite exercises two hardware D3D11 devices locally. CI does not run MGSV or a headset, and the badge does not certify VR playability. Development build artifacts are experimental. See [contributing](CONTRIBUTING.md) for the evidence requirements.
-
-## Check the selected OpenXR runtime
+1. Download **MGS5VR-experimental-2026-09-07.1.zip** from the [experimental release](https://github.com/nikamigaming-create/MGS5VR/releases/tag/experimental-2026-09-07.1). Extract the whole ZIP, keeping its folders together. Use the ZIP named MGS5VR, rather than GitHub's Source code download.
+2. Find your game's folder using Steam's **Browse local files** option. It must contain `mgsvtpp.exe`.
+3. Open the extracted **MGS5VR** folder containing this README, `dinput8.dll` and `tools`. In File Explorer's address bar, type `powershell` and press Enter. Run this command, replacing the quoted path with your game's folder:
 
 ```powershell
-.\build\Release\mgs5vr_probe.exe
-.\build\Release\mgs5vr_probe.exe --session-seconds 10
+.\tools\install.ps1 -GameDir 'D:\SteamLibrary\steamapps\common\MGS_TPP' -EnableVR
 ```
 
-The second command creates a bounded session without game pixels. Exit status distinguishes missing headset (2), no progressing session (3), and session failure (4). The probe also prints a structured error. Some runtimes print their own diagnostics alongside the JSON.
+`-EnableVR` enables tracked VR, hands, weapons and the left-wrist HUD together.
+The installer records its files for removal and leaves game data and saves intact.
+If Windows blocks the script, see [PowerShell setup](docs/ADVANCED_SETUP.md#powershell-blocks-the-installer).
 
-For a locally installed simulator, set `XR_RUNTIME_JSON` only in the launching PowerShell process to that simulator's manifest. This project does not change the system OpenXR registry selection. Simulator validation cannot certify a physical headset.
+## Play
 
-## Install the current preview
+1. Connect your headset and launch MGSV normally through Steam.
+2. Use the game's **Action Type** controller layout. Choose **Continue → Resume Game**.
+3. Once gameplay has loaded, **hold left grip and click the left stick** to enter VR. Repeat that combination to return to the large game screen.
 
-Extract the complete archive from the [experimental downloads](https://github.com/nikamigaming-create/MGS5VR/releases), including its tools, documentation, profile and licenses. Windows x64, the supported game build, an installed OpenXR runtime and the [Microsoft Visual C++ v14 x64 Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) are required. A source checkout must be built first.
+Title and loading screens use the large screen; enter tracked VR after loading
+your save. Installation is only needed once.
 
-Close the game first. The installer supports only the recorded SHA256 of TPP 1.0.15.4, refuses existing proxy/config files, and records hashes for removal. It does not modify the executable, game archives, or saves.
+## Essential Touch controls
 
-```powershell
-.\tools\install.ps1 -GameDir 'D:\SteamLibrary\steamapps\common\MGS_TPP' -EnableTheatrePreview
-```
+| Action | Control |
+| --- | --- |
+| Move / turn | Left stick / right stick |
+| Ready / fire | Hold right grip, then right trigger |
+| Support the weapon | Bring the left hand near it, or hold left grip |
+| Reload | Right B |
+| Read ammo and status | Raise your left forearm |
+| Select a primary weapon | Release right grip; hold left trigger + left stick up, browse with the right stick, then release |
+| Interact / pick up | Left Y when the game offers the action |
+| iDroid / pause | Tap left Menu / hold left Menu |
 
-For the tracked VR test with hands and the left-wrist HUD, install with all five switches:
+Weapon selection cards open above the left wrist. Full iDroid and pause menus
+use the large screen. [All controls, equipment categories and test limits →](docs/CONTROLS.md)
 
-```powershell
-.\tools\install.ps1 -GameDir 'D:\SteamLibrary\steamapps\common\MGS_TPP' -EnableTheatrePreview -EnableCameraObserver -EnableHeadCameraExperiment -EnableControllerRigExperiment -EnableWristHudExperiment
-```
+## Picture settings
 
-In loaded gameplay, hold left grip and click the left stick to toggle native VR.
-Tracking stalls suspend eye submission and resume from the same head origin.
-This enables tracked hands/arms and the native weapon/status display on the
-**left forearm**. These options remain disabled by default.
+The current test setup uses **Windowed**, **Depth of Field: Disable**,
+**Motion Blur: Off**, **Post Processing: Off**, and **Camera Shake: Off**.
+Post Processing Off also removes the game's anti-aliasing, so jagged edges remain
+a known limitation; see the [sharpness review](docs/HEADSET_SHARPNESS_REVIEW.md).
 
-Right grip readies the weapon; right trigger fires; left grip requests support;
-right B reloads. Left trigger plus left-stick direction selects equipment.
-Activation uses anatomical hand landmarks rather than an arbitrary ready pose.
-Flat crosshairs and destination labels are suppressed; native 3D people cues remain.
-Binocular and scope zoom are reserved, so aiming cannot switch to a mono screen.
-See the [complete Touch interaction list](docs/CONTROLS.md) for one/two-handed use,
-weapon selection, menus, movement and the exact test limits.
+The positively reviewed baseline used **1920×1080**. **2560×1440** is the current
+sharpness test with the same mod binary; its visual improvement and sustained
+performance still need confirmation. [Resolution setup →](docs/ADVANCED_SETUP.md#runtime-and-resolution)
 
-For the current VR test setup, use native Graphics Settings to set Depth of Field to Disable, Motion Blur to Off, and Post-Processing to Off. Set Camera Shake to Off in Camera Settings. These saved settings were exercised in the simulator; they do not establish that every cinematic or temporal effect is disabled.
+## Current limits
 
-The positively reviewed Quest 3 baseline used native 1920x1080 rendering. A 2560x1440 sharpness test is running with the same DLL; its visual improvement and sustained performance remain unconfirmed. To request that mode after closing the game, use the selected physical runtime:
+- Arm/cuff polish, sharpness and some blue marker artifacts remain under review.
+- Pause and iDroid use a large screen; keeping the stereo world around every menu remains unfinished.
+- Optical scope/binocular zoom is unavailable. Vehicles, every weapon and every interaction are not fully tested.
+- Metal Gear Online is unsupported.
 
-```powershell
-$mgsRuntime = (Get-ItemProperty 'HKLM:\SOFTWARE\Khronos\OpenXR\1').ActiveRuntime
-.\tools\launch-simulator.ps1 -GameDir 'D:\SteamLibrary\steamapps\common\MGS_TPP' -RuntimeManifest $mgsRuntime -RenderWidth 2560 -RenderHeight 1440
-```
+This is a playable experiment, not a finished conversion. The [acceptance matrix](docs/ACCEPTANCE.md) records the remaining work.
 
-Despite its name, this launcher uses the supplied runtime; a physical run omits `-Headless` and `-OperatorDir`. It backs up changed graphics settings and preserves the global runtime selection. Confirm `Game Present ... size=2560x1440` in `mgs5vr.log`, because unsupported modes can be substituted by the game. The [sharpness review](docs/HEADSET_SHARPNESS_REVIEW.md) separates the working baseline from the higher-resolution test.
+## Update or remove
 
-The current DLL takes the `dinput8.dll` slot and cannot yet be chained with IHHook or another DirectInput proxy. It activates only in `mgsvtpp.exe`, never `mgsvmgo.exe`. The module remains loaded until process exit. Restart the game to replace it.
-
-With Meta XR Operator loaded, closing the game can take roughly 20 seconds while the runtime and Operator server finish shutting down. The preview requests normal OpenXR session exit and allows up to 30 seconds for cleanup before native process exit. One native exit completed, but later sessions stalled at instance destruction; shutdown reliability remains unresolved.
-
-The default Touch mapping passes A/B/X/Y, sticks, triggers, grip buttons and stick clicks to the corresponding Xbox controls; the controller experiment changes grip behavior as described above. Tap left Menu for Start/iDroid; hold it for at least 0.55 seconds for Back/Pause. Both paths have been exercised in the game through Meta XR Operator. Tracking/focus loss and stale samples release virtual inputs. Other controller profiles have incomplete bindings. The tracked-rig equipment modifier supplies D-pad category selection.
-
-Use Continue and then Resume Game to load the existing checkpoint and its equipped gear. This path was exercised with the saved AM MRS-4. The current save uses the game's Action Type layout. The tracked-rig mapping is documented above; the large-screen mode retains ordinary gamepad mappings. Left X is a quick dive outside aim, not reload. Automatic startup directly into the save is not implemented.
-
-Edit `mgs5vr.ini` while the game is closed: `width_cm=800`, `distance_cm=600`. Supported range is 100–3000 cm. Hold both grips and click the right stick to recenter the screen. Suggested bindings on other controllers are unverified; simple controllers lack the grip chord. Cinematic skipping uses the game's existing controls; no universal skip hook is present.
-
-For simulator testing, `tools/launch-simulator.ps1` takes `-GameDir`, `-RuntimeManifest`, optional `-OperatorDir`, and `-Headless` for Elliott's headless simulator. Headless runs default to a normal **1280×720 window**; other launches preserve the selected game resolution. Supply both `-RenderWidth` and `-RenderHeight` to request another supported game mode. The launcher backs up changed graphics configuration and sets runtime variables only for the launched process. It preserves the system OpenXR registry. The chosen runtime and Operator must already be installed. Check the actual rendered dimensions in the log: the game may substitute an unsupported mode.
-
-The optional `-EnableCameraObserver` installation switch enables a version-checked diagnostic setter hook. It records retail camera transforms and does not alter the camera. It is development evidence, not a 6DoF mode.
-
-## Remove
+Close the game and run this from the extracted mod folder:
 
 ```powershell
 .\tools\uninstall.ps1 -GameDir 'D:\SteamLibrary\steamapps\common\MGS_TPP'
 ```
 
-Modified files are preserved and require manual review. `mgs5vr.log` is retained for diagnostics.
+Removal deletes only the recorded, unchanged mod files and retains the diagnostic
+log. Modified files are preserved for review. To update, remove the old version
+first, then run the new version's installer.
 
-See [implementation status](docs/STATUS.md), [architecture](docs/ARCHITECTURE.md), [acceptance matrix](docs/ACCEPTANCE.md), and the [development handoff](docs/HANDOFF.md) before testing. They distinguish implemented code, verified behavior, and outstanding work.
+## More information
+
+[Advanced setup and troubleshooting](docs/ADVANCED_SETUP.md) ·
+[Development and building](docs/ADVANCED_SETUP.md#build-from-source) ·
+[Contributing](CONTRIBUTING.md)
+
+Independent community project. Mod source is [MIT licensed](LICENSE);
+[dependency notices](docs/THIRD_PARTY_NOTICES.md) are included. Downloads contain
+no game data.
+
+[![Windows build](https://github.com/nikamigaming-create/MGS5VR/actions/workflows/windows.yml/badge.svg?branch=main)](https://github.com/nikamigaming-create/MGS5VR/actions/workflows/windows.yml)

--- a/config/mgs5vr.ini
+++ b/config/mgs5vr.ini
@@ -1,6 +1,6 @@
 ; Development preview with optional native same-frame stereo experiment.
 ; Native stereo, tracked arms and wrist HUD are opt-in experiments; physical acceptance is incomplete.
-; Install with tools/install.ps1 -EnableTheatrePreview to opt into the current preview.
+; Install with tools/install.ps1 -EnableVR for tracked VR, hands and the left-wrist HUD.
 [theatre]
 enabled=0
 width_cm=800

--- a/docs/ADVANCED_SETUP.md
+++ b/docs/ADVANCED_SETUP.md
@@ -1,0 +1,143 @@
+# Advanced setup and development
+
+For normal play, start with the [README quick start](../README.md). This guide
+covers individual options, diagnostics and building from source.
+
+## Installer options
+
+`-EnableVR` enables the existing tracked VR configuration: OpenXR presentation,
+the camera observer, native head tracking/stereo, tracked hands and weapons, and
+the left-wrist HUD. It is a shortcut for all five switches below. It does not
+change the runtime binary or mark incomplete features as accepted.
+
+| Switch | Purpose and dependencies |
+| --- | --- |
+| `-EnableTheatrePreview` | Present the game on a large OpenXR screen. |
+| `-EnableCameraObserver` | Enable the version-checked camera observer; this alone does not enable head tracking. |
+| `-EnableHeadCameraExperiment` | Enable native head tracking/stereo; requires the two preceding options. |
+| `-EnableControllerRigExperiment` | Enable tracked hands and weapons; requires the head-camera experiment. |
+| `-EnableWristHudExperiment` | Enable the left-forearm HUD; requires the controller rig. |
+| `-CameraEvidenceDir` | Absolute private directory for bounded camera snapshots; requires the observer. |
+
+Without switches, the installer leaves all experiments disabled. The supported
+TPP 1.0.15.4 executable has SHA256
+`085c2f82d1c963c40b3d2d55786661dfee2b18cbbf388a710c00fa76c5e9bb45`.
+The installer checks this before copying files and refuses existing
+`dinput8.dll`, `mgs5vr.ini` or `mgs5vr-install.json` files. It records installed
+hashes so removal can preserve modified files. It cannot chain IHHook or another
+DirectInput proxy. Activation is restricted to `mgsvtpp.exe`, never `mgsvmgo.exe`.
+
+## PowerShell blocks the installer
+
+Use the ZIP from this project's release page and review its scripts. If Windows
+marked the download as blocked, right-click the ZIP, open **Properties**, select
+**Unblock** if offered, then extract it again. If PowerShell reports that running
+scripts is disabled, the following setting applies only to that PowerShell
+session; run the installer again afterward:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned
+```
+
+This does not change the machine's policy. Organization policy can still take
+precedence. See Microsoft's [execution policy documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+
+## Runtime and resolution
+
+A simulator is not required for headset play. Connect through your headset's PC
+software and select it as the active OpenXR runtime. The physical baseline uses
+Quest 3, Touch controllers and the Meta PC runtime. Other hardware remains
+unverified; the controls assume the game's **Action Type** layout.
+
+The positively reviewed baseline used native 1920x1080 rendering. The current
+2560x1440 test keeps the same DLL; its visual improvement and sustained performance
+await physical feedback. Close the game before requesting that mode:
+
+```powershell
+$mgsRuntime = (Get-ItemProperty 'HKLM:\SOFTWARE\Khronos\OpenXR\1').ActiveRuntime
+.\tools\launch-simulator.ps1 -GameDir 'D:\SteamLibrary\steamapps\common\MGS_TPP' -RuntimeManifest $mgsRuntime -RenderWidth 2560 -RenderHeight 1440
+```
+
+Despite its name, this launcher uses the supplied runtime. A physical run omits
+`-Headless` and `-OperatorDir`. It selects Windowed mode, backs up changed graphics
+settings in the extracted mod's `artifacts` folder, and preserves the global
+OpenXR runtime selection. If more than one Steam account has a graphics config,
+supply `-GraphicsConfig` with the chosen account's absolute
+`userdata/<account>/287700/local/TPP_GRAPHICS_CONFIG` path.
+
+Check `Game Present ... size=2560x1440` in the game's `mgs5vr.log`: the game may
+substitute unsupported display modes. Enlarging an XR image alone cannot recover
+detail missing from the native render. The [sharpness review](HEADSET_SHARPNESS_REVIEW.md)
+records the observed dimensions, performance and remaining anti-aliasing test.
+
+## Large screen, menus and transitions
+
+Tap left Menu for iDroid; hold it for at least 0.55 seconds for pause. These use
+the large game screen. A confirms, B goes back, sticks navigate, grips act as
+LB/RB, and triggers retain LT/RT. Close iDroid with B or hold Menu again to unpause.
+Tracked VR returns when the same player camera resumes. Release held inputs once
+before moving or firing again. The manual left-grip + left-stick-click toggle
+remains available; switching VR off inside a menu disables automatic return.
+
+Hold both grips and click the right stick to recenter the large screen. To resize
+it, edit `mgs5vr.ini` with the game closed: defaults are `width_cm=800` and
+`distance_cm=600`, with a supported range of 100-3000 cm. Other controller profiles
+have incomplete bindings. Cinematic skipping uses the game's controls; automatic
+save loading and universal cinematic skipping are not implemented.
+
+The module stays loaded until process exit; restart before replacing it. With
+Meta XR Operator, shutdown can take roughly 20 seconds. Cleanup allows up to 30
+seconds, but later sessions have stalled at instance destruction. Shutdown
+reliability and all cinematic/loading transitions remain open acceptance items.
+
+## Check the OpenXR runtime
+
+From an extracted release, with other VR applications closed:
+
+```powershell
+.\mgs5vr_probe.exe
+.\mgs5vr_probe.exe --session-seconds 10
+```
+
+The second command creates a bounded session without game pixels. Exit codes
+distinguish missing headset (2), no progressing session (3), and session failure
+(4). The probe prints structured errors; runtimes may add their own diagnostics.
+In a source build the executable is under `build/Release/`.
+
+## Build from source
+
+Requires Windows x64, Visual Studio 2022 C++ build tools and Windows SDK, Git,
+CMake 3.24+, and Python 3. Run from the repository:
+
+```powershell
+.\tools\build.ps1
+```
+
+Dependencies are pinned: Khronos OpenXR SDK 1.1.49 (`977f6675...`) and MinHook
+1.3.4 (`c3fcafdc...`). The OpenXR loader is statically linked. The Visual C++
+runtime is required. Outputs are in `build/Release/`. CI runs four suites that do
+not need a GPU; the fifth suite exercises two hardware D3D11 devices locally.
+CI does not run the game or certify headset playability.
+
+Stage a player package without dependency SDK headers and libraries:
+
+```powershell
+cmake --install build --config Release --component MGS5VR --prefix dist/MGS5VR-development
+```
+
+See [contributing](../CONTRIBUTING.md), [architecture](ARCHITECTURE.md), and the
+[acceptance matrix](ACCEPTANCE.md) for implementation and evidence requirements.
+
+## Simulator testing
+
+`tools/launch-simulator.ps1` takes `-GameDir`, `-RuntimeManifest`, optional
+`-OperatorDir`, and `-Headless` for Elliott's headless simulator. The runtime and
+Operator must already be installed. Headless runs default to a normal 1280x720
+window; other launches preserve the selected resolution. Supply both
+`-RenderWidth` and `-RenderHeight` for another supported mode and check the actual
+rendered dimensions in the log.
+
+The launcher sets runtime variables only for the launched process and preserves
+the system OpenXR registry. Use semantic OpenXR/controller inputs for test
+automation, not OS keyboard/mouse injection or window activation. Simulator
+validation is separate from physical headset acceptance.

--- a/tools/install.ps1
+++ b/tools/install.ps1
@@ -1,5 +1,6 @@
 param(
     [Parameter(Mandatory=$true)][string]$GameDir,
+    [switch]$EnableVR,
     [switch]$EnableTheatrePreview,
     [switch]$EnableCameraObserver,
     [switch]$EnableHeadCameraExperiment,
@@ -8,6 +9,13 @@ param(
     [string]$CameraEvidenceDir
 )
 $ErrorActionPreference = 'Stop'
+if ($EnableVR) {
+    $EnableTheatrePreview = $true
+    $EnableCameraObserver = $true
+    $EnableHeadCameraExperiment = $true
+    $EnableControllerRigExperiment = $true
+    $EnableWristHudExperiment = $true
+}
 $mgsRoot = Split-Path -Parent $PSScriptRoot
 $mgsTarget = (Resolve-Path -LiteralPath $GameDir).Path
 $mgsExe = Join-Path $mgsTarget 'mgsvtpp.exe'
@@ -62,4 +70,8 @@ try {
     foreach ($mgsName in $mgsCreated) { Remove-Item -LiteralPath (Join-Path $mgsTarget $mgsName) }
     throw
 }
-Write-Output "Installed theatre preview into $mgsTarget (enabled=$($EnableTheatrePreview.IsPresent)). Game executable and archives were not modified."
+$mgsMode = if ($EnableHeadCameraExperiment) { 'tracked VR' } elseif ($EnableTheatrePreview) { 'large-screen preview' } else { 'disabled preview' }
+Write-Output "Installed MGS5VR ($mgsMode) into $mgsTarget. Game executable, archives and saves were not modified."
+if ($EnableHeadCameraExperiment) {
+    Write-Output 'Launch the game, load Continue/Resume Game, then hold left grip and click the left stick to enter VR.'
+}


### PR DESCRIPTION
Players previously had to read build/runtime internals and combine five installer switches to reach the tested VR configuration. The README now starts with download, one install command, entering VR, essential Touch controls and removal; diagnostics and source builds are in a separate packaged guide.

`-EnableVR` selects the same five existing options. Individual flags, disabled defaults, executable checks and install/uninstall protections remain available. Runtime code and the physically tested DLL are unchanged. The matching experimental download revision will include the new installer and README.

Validation: PowerShell parsing passed. Isolated installer fixtures on Windows PowerShell 5.1 and PowerShell 7 produced identical INI contents for `-EnableVR` and the original five switches, retained all five disabled defaults, refused existing/unsupported installations, and passed three install/uninstall round trips while preserving fixture game files and logs. These fixtures used authored non-executable files with scoped process/hash stubs; they did not touch or launch the game. The staged player package has 42 expected files, 54 valid local documentation links, no private/game/SDK payload, and the same `7BF543BE` DLL as the physical baseline.

This simplifies setup; it does not claim complete gameplay or headset acceptance. The existing sharpness and interaction limits remain explicit.