### PR TITLE
Superseded by #3: grenade pointing lab

### DIFF
--- a/docs/GRENADE_POINTING_PROTOTYPE.md
+++ b/docs/GRENADE_POINTING_PROTOTYPE.md
@@ -1,0 +1,31 @@
+# Grenade pointing prototype — failed visual acceptance
+
+This branch preserves the 2026-09-07 prototype for repair. It is not the installed
+candidate and must not be packaged as a passing release. The base branch retains
+only the wrist-menu direction correction.
+
+The prototype pairs the native grenade preview and actual-throw requests with a
+published right-hand origin and pointing direction. SIM observations reached both
+paths and two actual throws. Release build and six automated suites passed before
+capture, but the final 15-second recording showed disappearing hands during part
+of grenade readiness/throwing. That visual failure blocks acceptance.
+
+The private candidate DLL SHA-256 was
+`B631DA47A506FEF7A73D7325AE7F0B26398112480C55D81C01FC402F5F5A71FC`.
+The diagnostic recording and sampling limits are described in
+[the test review](MENU_GRENADE_REVIEW.md).
+
+Before another runtime pass:
+
+- Repair grenade-ready/throw hand visibility and verify the rig/animation state.
+- Make origin/velocity fallback atomic. The current 50 ms velocity-pair gate can
+  fall back after the origin was already overridden; that mixed request is unsafe
+  to retain as a finished implementation.
+- Check native throw-strength changes across stance and throw modes. The current
+  adapter preserves native strength; fixed range from hand tilt alone is not
+  established.
+- Recheck preview and actual throw against the same source pose, then perform
+  final-eye visual acceptance and a physical controller test.
+
+No headset session was launched for this prototype. The SIM was stopped after
+capture and the menu-only candidate was restored.

--- a/docs/GRENADE_POINTING_PROTOTYPE.md
+++ b/docs/GRENADE_POINTING_PROTOTYPE.md
@@ -1,5 +1,9 @@
 # Grenade pointing prototype — failed visual acceptance
 
+See the [focused follow-up](RIG_FOLLOWUP.md) for the subsequent support-release
+and atomic throw-pair corrections, newer SIM samples and the user's instruction
+to prioritize clarity. The original failure remains unresolved; this is a draft.
+
 This branch preserves the 2026-09-07 prototype for repair. It is not the installed
 candidate and must not be packaged as a passing release. The base branch retains
 only the wrist-menu direction correction.
@@ -18,9 +22,8 @@ The diagnostic recording and sampling limits are described in
 Before another runtime pass:
 
 - Repair grenade-ready/throw hand visibility and verify the rig/animation state.
-- Make origin/velocity fallback atomic. The current 50 ms velocity-pair gate can
-  fall back after the origin was already overridden; that mixed request is unsafe
-  to retain as a finished implementation.
+- Origin/velocity fallback is now atomic: both outputs are committed at the
+  matched velocity call, leaving native origin intact on a mismatch.
 - Check native throw-strength changes across stance and throw modes. The current
   adapter preserves native strength; fixed range from hand tilt alone is not
   established.

--- a/docs/RIG_FOLLOWUP.md
+++ b/docs/RIG_FOLLOWUP.md
@@ -1,0 +1,27 @@
+# Focused rig follow-up — 2026-09-07
+
+The user reports that normal headset arm behavior was mostly good and asked to
+prioritize distant image clarity. Broad pose and ground-placement changes are
+not retained from this follow-up.
+
+One targeted correction keeps a support-release blend anchored to the last
+presented contact instead of chasing a newly changing native stow animation.
+Menu entry, lowering, non-firearm selection and tracking loss release contact
+immediately. Native reload contact remains available while already attached.
+Regression cases cover acquisition, animation changes, reload, release and reset.
+
+The grenade adapter now writes origin and velocity together at the verified
+velocity call. An unmatched request leaves the original origin unchanged; there
+is no timeout path that mixes a modified origin with native velocity.
+
+The diagnostic DLL was
+`3496A4E2AD700CCAFC059F8B5A574BA998F7EB27DF1D182EB2CE879887776C28`.
+Release build and all six automated suites passed. Sampled final eyes retained
+both hands during grenade readiness and hand-directed aiming; a sampled actual
+throw also retained them. This did not reproduce or resolve the older low-pose
+failure, and it is not continuous or physical acceptance of the new changes.
+The installed menu-only baseline was restored after the SIM stopped.
+
+The earlier disappearing-arm clip remains diagnostic evidence. A possible
+uphill ground-query issue was investigated, but its proposed change was removed
+before another runtime test. Do not claim that hypothesis was confirmed.

--- a/include/mgs5vr/arm_ik.hpp
+++ b/include/mgs5vr/arm_ik.hpp
@@ -35,6 +35,10 @@ std::optional<Pose> anatomicalGrip(Pose wrist,Vec3 indexKnuckle,Vec3 littleKnuck
 // Swing the authored barrel direction toward the other controller while
 // keeping the primary palm fixed. Roll stays owned by the primary controller.
 std::optional<Pose> twoHandGrip(Pose primary,Pose support,Vec3 forwardInPrimary,float influence);
+struct PointThrow { Vec3 origin,velocity; };
+// Start at the rendered palm; point along OpenXR aim -Z. The native solver
+// supplies speed at neutral camera angles, so looking/turning cannot steer it.
+std::optional<PointThrow> pointThrow(Pose renderedPalm,Pose gripFromAim,Vec3 nativeVelocity);
 // Local rotations for the authored straight finger chains (thumb through pinky).
 // Native weapon/contact animation remains authoritative while a hand is attached.
 std::optional<Quat> fingerJointRotation(bool right,unsigned finger,unsigned joint,float curl);

--- a/include/mgs5vr/arm_ik.hpp
+++ b/include/mgs5vr/arm_ik.hpp
@@ -28,6 +28,17 @@ private:
     bool attached_{},candidate_{};
     uint64_t since_{},lastTime_{};
 };
+// Keep contact in the acquired weapon frame. During release, retain the last
+// presented offset so an unrelated stow animation cannot drag the free hand.
+class SupportPose {
+public:
+    std::optional<Pose> update(Pose nativeOffset,bool attached,bool manipulating);
+    void reset(){attached_=false;acquired_={};presented_.reset();}
+private:
+    bool attached_{};
+    Pose acquired_{};
+    std::optional<Pose> presented_;
+};
 // OpenXR grip frame from the native wrist and the index/little metacarpal heads.
 // Unlike activation-pose calibration this is independent of the camera and of
 // where the user happened to hold the controller when enabling VR.

--- a/src/arm_ik.cpp
+++ b/src/arm_ik.cpp
@@ -157,6 +157,15 @@ bool SupportContact::update(bool ready,bool tracked,float distance,uint64_t time
     if(time-since_>=150){attached_=true;candidate_=false;}
     return attached_;
 }
+std::optional<Pose> SupportPose::update(Pose nativeOffset,bool attached,bool manipulating){
+    if(!valid(nativeOffset)){reset();return {};}
+    if(attached){
+        if(!attached_)acquired_=nativeOffset;
+        presented_=manipulating?nativeOffset:acquired_;
+    }
+    attached_=attached;
+    return presented_;
+}
 std::optional<Pose> anatomicalGrip(Pose wrist,Vec3 indexKnuckle,Vec3 littleKnuckle){
     if(!valid(wrist)||!valid(Pose{{},indexKnuckle})||!valid(Pose{{},littleKnuckle}))return {};
     const auto across=littleKnuckle-indexKnuckle;

--- a/src/arm_ik.cpp
+++ b/src/arm_ik.cpp
@@ -171,6 +171,15 @@ std::optional<Pose> anatomicalGrip(Pose wrist,Vec3 indexKnuckle,Vec3 littleKnuck
     const auto center=wrist.position+along*0.55f;
     return nativeAffinePose({x.x,x.y,x.z,0,y.x,y.y,y.z,0,z.x,z.y,z.z,0,center.x,center.y,center.z,1});
 }
+std::optional<PointThrow> pointThrow(Pose renderedPalm,Pose gripFromAim,Vec3 nativeVelocity){
+    if(!valid(renderedPalm)||!valid(gripFromAim)||!valid(Pose{{},nativeVelocity}))return {};
+    const float speed=std::sqrt(dot(nativeVelocity,nativeVelocity));
+    if(speed<.1f||speed>100.f)return {};
+    auto direction=rotate(compose(renderedPalm,gripFromAim).orientation,{0,0,-1});
+    const float length=std::sqrt(dot(direction,direction));
+    if(!std::isfinite(length)||length<.9f||length>1.1f)return {};
+    return PointThrow{renderedPalm.position,direction*(speed/length)};
+}
 std::optional<Pose> nativeAffinePose(const std::array<float,16>& m){
     for(float f:m)if(!std::isfinite(f))return {};
     if(std::abs(m[3])+std::abs(m[7])+std::abs(m[11])+std::abs(m[15]-1)>0.001f)return {};

--- a/src/controller_rig.cpp
+++ b/src/controller_rig.cpp
@@ -49,6 +49,7 @@ uintptr_t boundModel{};
 uint64_t activation{},updates{};
 std::array<Vec3,2> bendHistory{};
 SupportContact supportContact;
+SupportPose supportPose;
 float supportBlend{};
 float aimBlend{};
 Quat guidedOffset{};
@@ -193,7 +194,7 @@ bool apply(void* context,void* binding,PoseRestore& restore){
             bendHistory[i]=bone(q,p,wrists[i]-1).position-bone(q,p,shoulders[i]).position;
         }
         boundOwner=owner;boundModel=model;activation=frame.activation;
-        supportContact.reset();
+        supportContact.reset();supportPose.reset();
         supportBlend=0;aimBlend=0;guidedOffset={};heldSupportOffset={};supportAt=now;
         log("Controller rig uses native anatomical palm frames; no activation-pose wrist calibration");
     }
@@ -287,6 +288,13 @@ bool apply(void* context,void* binding,PoseRestore& restore){
     const bool support=nearSupport;
     const float step=std::min(now>=supportAt?static_cast<float>(now-supportAt)/180.f:1.f,1.f);supportAt=now;
     supportBlend=std::clamp(supportBlend+(support?step:-step),0.f,1.f);
+    // A menu, stow, non-firearm or lost controller releases ownership now.
+    // Distance release can blend out, but never toward a new native stow pose.
+    if(!frame.controllers.weaponReady||!firearmActive||inspecting||!frame.controllers.hands[0].gripTracked){
+        supportBlend=0;aimBlend=0;supportPose.reset();
+    }
+    const auto presentedSupport=supportPose.update(supportOffset,nearSupport,nativeManipulation).value_or(supportOffset);
+    attached=compose(right->pose.wrist,presentedSupport);
     bool guiding=nearSupport&&nativeManipulation&&aimBlend>0;
     if(barrelInGrip&&frame.controllers.hands[0].gripTracked&&nearSupport){
         if(const auto guided=twoHandGrip(grips[1],grips[0],*barrelInGrip,1.f)){
@@ -304,7 +312,7 @@ bool apply(void* context,void* binding,PoseRestore& restore){
         if(!right)return false;
         replace(q,p,10,right->pose.shoulder);replace(q,p,11,right->pose.elbow);replace(q,p,12,right->pose.wrist);
         bendHistory[1]=right->pose.elbow.position-right->pose.shoulder.position;
-        attached=compose(right->pose.wrist,supportOffset);
+        attached=compose(right->pose.wrist,presentedSupport);
     }
     if(supportBlend>=1){
         // Lift the held weapon and its support contact together; do not slide
@@ -317,7 +325,7 @@ bool apply(void* context,void* binding,PoseRestore& restore){
                 right=raised;
                 replace(q,p,10,right->pose.shoulder);replace(q,p,11,right->pose.elbow);replace(q,p,12,right->pose.wrist);
                 bendHistory[1]=right->pose.elbow.position-right->pose.shoulder.position;
-                attached=compose(right->pose.wrist,supportOffset);
+                attached=compose(right->pose.wrist,presentedSupport);
             }
         }
     }
@@ -424,13 +432,18 @@ bool apply(void* context,void* binding,PoseRestore& restore){
         shotRig.throwTracked=true;
     }
     if(++updates%120==1){
+        const auto headFromModel=compose(inverse(frame.nativePose),*root);
+        const auto leftView=compose(headFromModel,bone(q,p,8)).position;
+        const auto rightView=compose(headFromModel,bone(q,p,12)).position;
         std::ostringstream s;s<<"Controller rig updates="<<updates<<" tracking="<<frame.trackingSequence
             <<" predicted="<<frame.controllers.predictedXrTime<<" player="<<frame.playerSequence
             <<" right_wrist="<<right->pose.wrist.position.x<<','<<right->pose.wrist.position.y<<','<<right->pose.wrist.position.z
             <<" reach_clamped="<<right->reachClamped<<" support="<<supportBlend<<" support_aim="<<aimBlend<<" articulated_hands="<<articulatedHands
             <<" support_near="<<nearSupport<<" support_distance="<<std::sqrt(dot(separation,separation))
             <<" hand_distance="<<std::sqrt(dot(handSeparation,handSeparation))
-            <<" inspecting="<<inspecting<<" arm_helpers="<<helpersMatch<<" ground_contacts="<<groundContacts;log(s.str());
+            <<" inspecting="<<inspecting<<" arm_helpers="<<helpersMatch<<" ground_contacts="<<groundContacts
+            <<" left_head="<<leftView.x<<','<<leftView.y<<','<<leftView.z
+            <<" right_head="<<rightView.x<<','<<rightView.y<<','<<rightView.z;log(s.str());
     }
     return true;
 }
@@ -511,6 +524,7 @@ struct PendingThrow {
     uintptr_t velocityCaller{};
     uint64_t time{},tracking{},rig{};
     PointThrow solution{};float velocityW{};
+    Vector4* origin{};
 };
 thread_local PendingThrow pendingThrow;
 std::optional<PendingThrow> controllerThrow(void* context,void* state,uint32_t index,uintptr_t velocityCaller){
@@ -562,15 +576,18 @@ void throwOrigin(void* context,void* state,uint32_t index,Vector4* origin,Vector
     if(!velocityCaller)return;
     if(const auto request=controllerThrow(context,state,index,velocityCaller)){
         pendingThrow=*request;
-        origin->x=request->solution.origin.x;origin->y=request->solution.origin.y;origin->z=request->solution.origin.z;
+        pendingThrow.origin=origin;
     }
 }
 void throwVelocity(void* context,void* state,uint32_t index,Vector4* velocity){
     const auto caller=reinterpret_cast<uintptr_t>(_ReturnAddress());
     const auto request=pendingThrow;pendingThrow={};
-    const auto now=steadyMilliseconds();
     if(request.context!=context||request.state!=state||request.index!=index||request.velocityCaller!=caller
-       ||now<request.time||now-request.time>50){originalThrowVelocity(context,state,index,velocity);return;}
+       ||!request.origin){originalThrowVelocity(context,state,index,velocity);return;}
+    // Both verified callers retain the origin in their own request storage and
+    // call velocity immediately next. Publish the pair here: an unmatched call
+    // leaves the original origin intact, including after a scheduling delay.
+    request.origin->x=request.solution.origin.x;request.origin->y=request.solution.origin.y;request.origin->z=request.solution.origin.z;
     *velocity={request.solution.velocity.x,request.solution.velocity.y,request.solution.velocity.z,request.velocityW};
     static std::atomic_uint64_t requests{};
     const auto count=++requests;

--- a/src/controller_rig.cpp
+++ b/src/controller_rig.cpp
@@ -35,6 +35,10 @@ struct PoseRestore {
 };
 using Shot=void(*)(void*,Vector4*,Vector4*,void*,uint32_t);
 Shot originalShot{};
+using ThrowOrigin=void(*)(void*,void*,uint32_t,Vector4*,Vector4*);
+using ThrowVelocity=void(*)(void*,void*,uint32_t,Vector4*);
+ThrowOrigin originalThrowOrigin{};
+ThrowVelocity originalThrowVelocity{};
 uintptr_t base{};
 std::atomic_uintptr_t playerOwner{};
 std::atomic_bool enabled{};
@@ -54,6 +58,8 @@ struct ShotRig {
     uintptr_t owner{},character{},camera{},model{};
     Pose sourceCamera{},wristWorld{};
     uint64_t trackingSequence{};
+    Pose palmWorld{},gripFromAim{};
+    bool throwTracked{};
 } shotRig;
 template<class T> bool read(uintptr_t address,T& out){
     SIZE_T count{};return address&&ReadProcessMemory(GetCurrentProcess(),reinterpret_cast<void*>(address),&out,sizeof(out),&count)&&count==sizeof(out);
@@ -226,7 +232,7 @@ bool apply(void* context,void* binding,PoseRestore& restore){
     if(!right)return false;
     replace(q,p,10,right->pose.shoulder);replace(q,p,11,right->pose.elbow);replace(q,p,12,right->pose.wrist);
     bendHistory[1]=right->pose.elbow.position-right->pose.shoulder.position;
-    bool nativeManipulation=false,firearmActive=false;
+    bool nativeManipulation=false,firearmActive=false,throwableActive=false;
     std::optional<Vec3> barrelInGrip;
     const auto weaponComponent=get<uintptr_t>(character+0x80);
     if(!frame.controllers.vehicleControls&&get<uintptr_t>(weaponComponent)==base+0x23b3e80&&get<uintptr_t>(weaponComponent+8)==character){
@@ -238,6 +244,7 @@ bool apply(void* context,void* binding,PoseRestore& restore){
             // native animation owns the support hand during these operations.
             nativeManipulation=(get<uint32_t>(state+0x27c)&0x1c0)==0x40&&(get<uint32_t>(state+0x3c0)&0x04000000)!=0;
             firearmActive=(get<uint32_t>(state+0x27c)&0x1c0)==0x40;
+            throwableActive=(get<uint32_t>(state+0x27c)&0x1c0)==0x80;
             const auto flags=get<uint32_t>(state+0x27c),mode=get<uint32_t>(state+0x3c0);
             if(frame.controllers.weaponReady&&firearmActive&&!nativeManipulation&&!(flags&0x400000)&&!(mode&0x2000)){
                 // Use the same authored barrel frame as the native shot path.
@@ -368,7 +375,7 @@ bool apply(void* context,void* binding,PoseRestore& restore){
     unsigned articulatedHands{};
     for(size_t side=0;side<2;++side){
         const auto& hand=frame.controllers.hands[side];
-        const float contact=side?((frame.controllers.weaponReady&&firearmActive)?1.f:0.f):supportBlend;
+        const float contact=side?((frame.controllers.weaponReady&&(firearmActive||throwableActive))?1.f:0.f):supportBlend;
         if(!hand.gripTracked||frame.controllers.vehicleControls||contact>=1)continue;
         for(size_t finger=0;finger<5;++finger)for(size_t joint=0;joint<3;++joint){
             const auto i=fingers[side][finger]+joint;
@@ -410,6 +417,12 @@ bool apply(void* context,void* binding,PoseRestore& restore){
     std::memcpy(reinterpret_cast<void*>(rotations),q.data(),count*16u);
     std::memcpy(reinterpret_cast<void*>(positions),p.data(),count*16u);
     shotRig={owner,character,camera,model,nativeCamera,compose(*root,right->pose.wrist),frame.trackingSequence};
+    const auto& throwingHand=frame.controllers.hands[1];
+    if(throwableActive&&frame.controllers.weaponReady&&!frame.controllers.vehicleControls&&throwingHand.aimTracked){
+        shotRig.palmWorld=compose(shotRig.wristWorld,inverse(gripFromWrist[1]));
+        shotRig.gripFromAim=compose(inverse(throwingHand.grip),throwingHand.aim);
+        shotRig.throwTracked=true;
+    }
     if(++updates%120==1){
         std::ostringstream s;s<<"Controller rig updates="<<updates<<" tracking="<<frame.trackingSequence
             <<" predicted="<<frame.controllers.predictedXrTime<<" player="<<frame.playerSequence
@@ -493,6 +506,81 @@ void shot(void* context,Vector4* origin,Vector4* direction,void* state,uint32_t 
             <<" direction="<<direction->x<<','<<direction->y<<','<<direction->z;log(s.str());}
     }
 }
+struct PendingThrow {
+    void* context{};void* state{};uint32_t index{};
+    uintptr_t velocityCaller{};
+    uint64_t time{},tracking{},rig{};
+    PointThrow solution{};float velocityW{};
+};
+thread_local PendingThrow pendingThrow;
+std::optional<PendingThrow> controllerThrow(void* context,void* state,uint32_t index,uintptr_t velocityCaller){
+    if(!enabled.load()||!headCamera().active())return {};
+    ShotRig rig;{std::lock_guard lock(rigMutex);rig=shotRig;}
+    if(!rig.throwTracked||!rig.owner||rig.owner!=playerOwner.load())return {};
+    const auto component=reinterpret_cast<uintptr_t>(context),weapon=reinterpret_cast<uintptr_t>(state);
+    if(get<uintptr_t>(component)!=base+0x23b3e80||get<uintptr_t>(component+8)!=rig.character
+       ||get<uintptr_t>(rig.character+0x80)!=component||get<uintptr_t>(rig.owner+0x370)!=rig.character)return {};
+    const auto first=get<uint32_t>(get<uintptr_t>(component+0x38)+0x24);
+    if(index!=get<uint32_t>(rig.owner+0x3a0)||index<first||index-first>15
+       ||weapon!=get<uintptr_t>(component+0x58)+(index-first)*0x610ull
+       ||(get<uint32_t>(weapon+0x27c)&0x1c0)!=0x80)return {};
+    const auto frame=headCamera().resolveCurrent(rig.camera,rig.sourceCamera);
+    if(!frame.applied||frame.playerOwner!=rig.owner||frame.trackingSequence!=rig.trackingSequence
+       ||!frame.controllers.weaponReady||frame.controllers.vehicleControls
+       ||!frame.controllers.hands[1].gripTracked||!frame.controllers.hands[1].aimTracked)return {};
+    // This verified velocity helper reads only context+8/+60, character+78,
+    // and render+8/+290 before consulting the unchanged equipment database.
+    // Give it caller-owned copies with neutral pitch/yaw. Never patch the live
+    // camera or shared player angles just to change grenade throw strength.
+    alignas(16) std::array<std::byte,0x68> privateContext{};
+    alignas(16) std::array<std::byte,0x80> privateCharacter{};
+    alignas(16) std::array<std::byte,0x298> privateRender{};
+    std::array<float,2> angles{};
+    if(!read(component,privateContext)||!read(rig.character,privateCharacter))return {};
+    const auto characterAddress=reinterpret_cast<uintptr_t>(privateCharacter.data());
+    const auto renderAddress=reinterpret_cast<uintptr_t>(privateRender.data());
+    const auto anglesAddress=reinterpret_cast<uintptr_t>(angles.data());
+    std::memcpy(privateContext.data()+8,&characterAddress,8);
+    std::memcpy(privateCharacter.data()+0x78,&renderAddress,8);
+    std::memcpy(privateRender.data()+8,&index,4);
+    std::memcpy(privateRender.data()+0x290,&anglesAddress,8);
+    alignas(16) Vector4 velocity{};
+    originalThrowVelocity(privateContext.data(),state,index,&velocity);
+    const auto solution=pointThrow(rig.palmWorld,rig.gripFromAim,{velocity.x,velocity.y,velocity.z});
+    if(!solution)return {};
+    return PendingThrow{context,state,index,velocityCaller,steadyMilliseconds(),frame.trackingSequence,
+        frame.rigSequence,*solution,velocity.w};
+}
+void throwOrigin(void* context,void* state,uint32_t index,Vector4* origin,Vector4* rotation){
+    const auto caller=reinterpret_cast<uintptr_t>(_ReturnAddress());
+    originalThrowOrigin(context,state,index,origin,rotation);
+    pendingThrow={};
+    // The two native request paths both consume origin immediately followed
+    // by velocity. Keep that pair on one published rig generation and thread.
+    const auto velocityCaller=caller==base+0x1061eac?base+0x1061ebe:
+        caller==base+0x1087b16?base+0x1087b28:0;
+    if(!velocityCaller)return;
+    if(const auto request=controllerThrow(context,state,index,velocityCaller)){
+        pendingThrow=*request;
+        origin->x=request->solution.origin.x;origin->y=request->solution.origin.y;origin->z=request->solution.origin.z;
+    }
+}
+void throwVelocity(void* context,void* state,uint32_t index,Vector4* velocity){
+    const auto caller=reinterpret_cast<uintptr_t>(_ReturnAddress());
+    const auto request=pendingThrow;pendingThrow={};
+    const auto now=steadyMilliseconds();
+    if(request.context!=context||request.state!=state||request.index!=index||request.velocityCaller!=caller
+       ||now<request.time||now-request.time>50){originalThrowVelocity(context,state,index,velocity);return;}
+    *velocity={request.solution.velocity.x,request.solution.velocity.y,request.solution.velocity.z,request.velocityW};
+    static std::atomic_uint64_t requests{};
+    const auto count=++requests;
+    if(count%120==1||caller==base+0x1087b28){
+        std::ostringstream s;s<<"Controller throw requests="<<count<<" caller="<<std::hex<<caller-base<<std::dec
+            <<" tracking="<<request.tracking<<" rig="<<request.rig
+            <<" origin="<<request.solution.origin.x<<','<<request.solution.origin.y<<','<<request.solution.origin.z
+            <<" velocity="<<velocity->x<<','<<velocity->y<<','<<velocity->z;log(s.str());
+    }
+}
 }
 namespace mgs5vr {
 void installControllerRig(uintptr_t imageBase){
@@ -520,6 +608,19 @@ void installControllerRig(uintptr_t imageBase){
     if(status!=MH_OK)throw std::runtime_error(std::string("Controller shot create: ")+MH_StatusToString(status));
     status=MH_EnableHook(shotAddress);
     if(status!=MH_OK)throw std::runtime_error(std::string("Controller shot enable: ")+MH_StatusToString(status));
+    if(!matches(0x1037ba0,std::array<unsigned char,13>{0x48,0x8b,0xc4,0x55,0x53,0x56,0x57,0x41,0x54,0x41,0x56,0x41,0x57})
+       ||!matches(0x1039020,std::array<unsigned char,9>{0x48,0x8b,0xc4,0x55,0x53,0x56,0x57,0x41,0x56}))
+        throw std::runtime_error("Controller throw helper signatures differ");
+    const auto originAddress=reinterpret_cast<void*>(base+0x1037ba0),velocityAddress=reinterpret_cast<void*>(base+0x1039020);
+    status=MH_CreateHook(originAddress,reinterpret_cast<void*>(&throwOrigin),reinterpret_cast<void**>(&originalThrowOrigin));
+    if(status!=MH_OK)throw std::runtime_error(std::string("Controller throw origin create: ")+MH_StatusToString(status));
+    status=MH_CreateHook(velocityAddress,reinterpret_cast<void*>(&throwVelocity),reinterpret_cast<void**>(&originalThrowVelocity));
+    if(status!=MH_OK){MH_RemoveHook(originAddress);throw std::runtime_error(std::string("Controller throw velocity create: ")+MH_StatusToString(status));}
+    status=MH_QueueEnableHook(originAddress);
+    if(status==MH_OK)status=MH_QueueEnableHook(velocityAddress);
+    if(status==MH_OK)status=MH_ApplyQueued();
+    if(status!=MH_OK){MH_RemoveHook(originAddress);MH_RemoveHook(velocityAddress);throw std::runtime_error(std::string("Controller throw enable: ")+MH_StatusToString(status));}
+    log("Controller throw origin and velocity adapters installed");
     enabled.store(true);log("Experimental controller rig installed at verified skin publication RVA 0x1a6caa0 and shot solver 0x1044ff0");
 }
 void observeControllerRigOwner(uintptr_t owner) noexcept{playerOwner.store(owner);}

--- a/src/player_visibility.cpp
+++ b/src/player_visibility.cpp
@@ -3,6 +3,7 @@
 #include <windows.h>
 #include <array>
 #include <algorithm>
+#include <sstream>
 
 namespace {
 uintptr_t base{};
@@ -105,6 +106,16 @@ void conceal(Binding candidate){
     std::array<bool,128> bodyConceal{};
     if(candidate.body&&!bodyBranches(candidate.model,groups,count,bodyConceal))return;
     const auto flags=get<uintptr_t>(candidate.model+0x170);if(!flags)return;
+    if(candidate.body){
+        static uintptr_t observedModel{};
+        static std::array<uint32_t,3> observed{};
+        const std::array<uint32_t,3> current{groupFlags(candidate,armName),get<uint8_t>(flags),get<uint32_t>(candidate.model+0x1a4)};
+        if(observedModel!=candidate.model||observed!=current){
+            observedModel=candidate.model;observed=current;
+            std::ostringstream s;s<<"Player arm visibility arm="<<current[0]<<" root="<<current[1]<<" model="<<current[2];
+            mgs5vr::log(s.str());
+        }
+    }
     for(uint16_t i=0;i<count;++i){
         if(candidate.body&&!bodyConceal[i])continue;
         uint8_t previous{};if(!read(flags+i,previous)||!(previous&4))continue;

--- a/tests/core_tests.cpp
+++ b/tests/core_tests.cpp
@@ -378,6 +378,21 @@ int main(){
            "forearm HUD remains attached through character translation and turning");
     expect(!forearmPanel(watchElbow,watchWrist,{1,0,0}),"undefined forearm normal cannot produce a face HUD");
     SupportContact support;
+    SupportPose supportPose;
+    const Pose acquiredSupport{{},{.25f,0,.12f}},animatedReload{{},{.15f,.2f,.05f}},stowingSupport{{},{-.4f,2.f,-.3f}};
+    expect(!supportPose.update(acquiredSupport,false,false),"a free hand has no acquired support pose");
+    auto presentedSupport=supportPose.update(acquiredSupport,true,false);
+    expect(presentedSupport&&same(presentedSupport->position,acquiredSupport.position),"support acquires the current weapon contact");
+    presentedSupport=supportPose.update(stowingSupport,true,false);
+    expect(presentedSupport&&same(presentedSupport->position,acquiredSupport.position),"ordinary animation changes cannot move acquired support into the sky");
+    presentedSupport=supportPose.update(animatedReload,true,true);
+    expect(presentedSupport&&same(presentedSupport->position,animatedReload.position),"an attached native reload can animate contact");
+    presentedSupport=supportPose.update(stowingSupport,false,false);
+    expect(presentedSupport&&same(presentedSupport->position,animatedReload.position),"release blends from the last presented contact instead of chasing stow animation");
+    presentedSupport=supportPose.update(acquiredSupport,true,false);
+    expect(presentedSupport&&same(presentedSupport->position,acquiredSupport.position),"new contact reacquires its own weapon pose");
+    supportPose.reset();
+    expect(!supportPose.update(stowingSupport,false,false),"menu or tracking reset cannot retain a support presentation");
     expect(!support.update(true,true,.25f,1000)&&!support.update(true,true,.25f,1200),"a free palm away from the weapon support grip stays one-handed");
     expect(!support.update(true,true,.09f,1300)&&!support.update(true,true,.09f,1400)
         &&support.update(true,true,.09f,1450),"support engages only after dwelling at the actual weapon grip");

--- a/tests/core_tests.cpp
+++ b/tests/core_tests.cpp
@@ -13,6 +13,23 @@ static void expect(bool ok,const char* name){++checks;if(!ok){++failures;std::ce
 static bool near(float a,float b){return std::abs(a-b)<0.0001f;}
 static bool same(Vec3 a,Vec3 b){return near(a.x,b.x)&&near(a.y,b.y)&&near(a.z,b.z);}
 int main(){
+    {
+        const Pose palm{{},{2,3,4}};
+        const auto straight=pointThrow(palm,{},Vec3{3,4,0});
+        expect(straight&&same(straight->origin,palm.position)&&same(straight->velocity,{0,0,-5}),
+            "grenade starts at rendered palm and uses aim -Z with native speed");
+        const Pose aimPitch{{.70710678f,0,0,.70710678f},{.1f,0,-.1f}};
+        const auto upward=pointThrow(palm,aimPitch,Vec3{0,0,5});
+        expect(upward&&same(upward->origin,palm.position)&&same(upward->velocity,{0,5,0}),
+            "controller aim pitch raises grenade arc without moving its palm origin");
+        const Pose turned{{0,.70710678f,0,.70710678f},{-2,8,1}};
+        const auto side=pointThrow(turned,{},Vec3{0,5,0});
+        expect(side&&same(side->origin,turned.position)&&same(side->velocity,{-5,0,0}),
+            "translated and rotated rendered hand controls grenade launch in world space");
+        expect(!pointThrow(palm,{},{}),"zero native grenade speed cannot create a bogus arc");
+        expect(!pointThrow(palm,{},Vec3{0,std::numeric_limits<float>::quiet_NaN(),0}),"invalid grenade velocity is rejected");
+        expect(!pointThrow(Pose{{0,0,0,0},{}},{},Vec3{1,0,0}),"invalid hand transform is rejected for throwing");
+    }
     const EyeFov asymmetric{-0.8f,0.9f,0.75f,-0.7f};
     std::array<float,16> projection{1,0,0,0,0,1,0,0,0,0,-0.0002f,1,0,0,0.1f,0};
     expect(setEyeProjection(projection,asymmetric),"native perspective accepts runtime asymmetric field of view");


### PR DESCRIPTION
Superseded by draft #3, which now includes the guarded hand-directed grenade preview/throw adapter, support-contact corrections and later SIM evidence. The lab branch is preserved for the earlier diagnostics and failed prone/slope observations.

The combined EB89CE69 candidate passed the bounded ordinary-stance grenade sequence with both hands visible, including an actual throw in the reviewed short clip. Prone/slope occlusion and physical headset acceptance remain open. See [the current acceptance record](https://github.com/nikamigaming-create/MGS5VR/blob/codex/wrist-movement-forearms/docs/INTERACTION_VISIBILITY_REVIEW.md).

Closing this duplicate draft does not mean its changes are merged to main or packaged in a release.
